### PR TITLE
Checking if the user has requested a disconnect before connecting

### DIFF
--- a/src/com/qonect/protocols/mqtt/service/MqttService.java
+++ b/src/com/qonect/protocols/mqtt/service/MqttService.java
@@ -267,6 +267,13 @@ public class MqttService extends Service implements IMqttCallback
             return;
         }
         
+        if (connectionStatus == ConnectionStatus.NOTCONNECTED_USERDISCONNECT) {
+            // When calling startService in multiple activities, onStartCommand()
+            // is called when activies are switched. Thus the service would connect
+            // automatically even though the user might have requested the disconnect. 
+            return;
+        }
+        
         if (!isBackgroundDataEnabled()) // respect the user's request not to use data!
         {
             // user has disabled background data


### PR DESCRIPTION
While adapting the service for my project, I found it handy to check if the connection status is NOTCONNECTED_USERDISCONNECT to prevent connects during activity switches after the user has explicitly requested a disconnect. 
