### PR TITLE
Updated to include the name of the license used.

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright © 2014 Dirk Moors, dirkmoors@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:


### PR DESCRIPTION
I prefer to see the type of license listed at the beginning. Otherwise I have to look up the license and read each side by side to make sure it really is the MIT license.

Thanks.
